### PR TITLE
Update composer.lock to fix security alerts

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -787,7 +787,7 @@
                 "psr/log": "~1.0",
                 "psr/simple-cache": "^1.0",
                 "symfony/contracts": "^1.0",
-                "symfony/var-exporter": "^4.2"
+                "symfony/var-exporter": "^4.2.12"
             },
             "conflict": {
                 "doctrine/dbal": "<2.5",
@@ -1287,14 +1287,14 @@
             "require": {
                 "ext-xml": "*",
                 "php": "^7.1.3",
-                "symfony/cache": "~4.2",
+                "symfony/cache": "~4.2.12",
                 "symfony/config": "~4.2",
                 "symfony/contracts": "^1.0.2",
                 "symfony/dependency-injection": "^4.2.5",
                 "symfony/event-dispatcher": "^4.1",
                 "symfony/filesystem": "~3.4|~4.0",
                 "symfony/finder": "~3.4|~4.0",
-                "symfony/http-foundation": "^4.2.5",
+                "symfony/http-foundation": "^4.2.12",
                 "symfony/http-kernel": "^4.2",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/routing": "^4.2.8"


### PR DESCRIPTION
Three dependencies in this project required upgrade because of security issues:
- http-foundation
- var-exporter
- cache

They are all upgraded to the minimal required version to avoid security issues.

EDIT:
It's not enough to just change composer.lock values. Will fix this later.